### PR TITLE
Support Oculus Touch Controllers

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 		<script src="js/WebVR.js"></script>
 		<script src="js/effects/VREffect.js"></script>
 		<script src="js/controls/VRControls.js"></script>
-		<script src="js/ViveController.js"></script>
+		<script src="js/ViveOrTouchController.js"></script>
 
 		<script src="js/loaders/OBJLoader.js"></script>
 		<script src="js/MarchingCubes.js"></script>
@@ -122,11 +122,11 @@
 
 				// controllers
 
-				controller1 = new THREE.ViveController( 0 );
+				controller1 = new THREE.ViveOrTouchController( 0 );
 				controller1.standingMatrix = controls.getStandingMatrix();
 				scene.add( controller1 );
 
-				controller2 = new THREE.ViveController( 1 );
+				controller2 = new THREE.ViveOrTouchController( 1 );
 				controller2.standingMatrix = controls.getStandingMatrix();
 				scene.add( controller2 );
 

--- a/js/ViveOrTouchController.js
+++ b/js/ViveOrTouchController.js
@@ -3,7 +3,7 @@
  * @author stewdio / http://stewd.io
  */
 
-THREE.ViveController = function ( id ) {
+THREE.ViveOrTouchController = function ( id ) {
 
 	THREE.Object3D.call( this );
 
@@ -26,8 +26,7 @@ THREE.ViveController = function ( id ) {
 		for ( var i = 0, j = 0; i < 4; i ++ ) {
 
 			var gamepad = gamepads[ i ];
-
-			if ( gamepad && gamepad.id === 'OpenVR Gamepad' ) {
+			if ( gamepad && (gamepad.id === 'OpenVR Gamepad' || gamepad.id.startsWith('Oculus Touch') ) ) {
 
 				if ( j === id ) return gamepad;
 
@@ -61,7 +60,7 @@ THREE.ViveController = function ( id ) {
 
 		gamepad = findGamepad( id );
 
-		if ( gamepad !== undefined && gamepad.pose !== null ) {
+		if ( gamepad !== undefined && gamepad.pose !== null && gamepad.pose.position != null ) {
 
 			//  Position and orientation.
 
@@ -122,5 +121,5 @@ THREE.ViveController = function ( id ) {
 
 };
 
-THREE.ViveController.prototype = Object.create( THREE.Object3D.prototype );
-THREE.ViveController.prototype.constructor = THREE.ViveController;
+THREE.ViveOrTouchController.prototype = Object.create( THREE.Object3D.prototype );
+THREE.ViveOrTouchController.prototype.constructor = THREE.ViveOrTouchController;

--- a/js/effects/VREffect.js
+++ b/js/effects/VREffect.js
@@ -139,8 +139,8 @@ THREE.VREffect = function ( renderer, onError ) {
 					var layers = vrDisplay.getLayers();
 					if ( layers.length ) {
 
-						leftBounds = layers[0].leftBounds || [ 0.0, 0.0, 0.5, 1.0 ];
-						rightBounds = layers[0].rightBounds || [ 0.5, 0.0, 0.5, 1.0 ];
+						leftBounds = (layers[0].leftBounds && layers[0].leftBounds.length > 0) || [ 0.0, 0.0, 0.5, 1.0 ];
+						rightBounds = (layers[0].rightBounds && layers[0].rightBounds.length > 0) || [ 0.5, 0.0, 0.5, 1.0 ];
 
 					}
 
@@ -228,7 +228,6 @@ THREE.VREffect = function ( renderer, onError ) {
 				}
 
 			} else {
-
 				if ( canvas[ requestFullscreen ] ) {
 
 					canvas[ boolean ? requestFullscreen : exitFullscreen ]( { vrDisplay: vrDisplay } );


### PR DESCRIPTION
Vive and Touch controllers are similar, this PR is a small refactor of ViveController to turn it into ViveOrTouchController. A couple small semantic differences (e.g. oculus touch returns a pose in some cases where there's still no pose.position), but mostly it's just recognizing the Oculus Touch Controller's IDs.